### PR TITLE
Add a hashref return type

### DIFF
--- a/lib/Web/Scraper.pm
+++ b/lib/Web/Scraper.pm
@@ -149,6 +149,8 @@ sub create_process {
                 }
             } elsif ($key =~ s!\[\]$!!) {
                 $stash->{$key} = [ map __get_value($_, $val, $uri), @nodes ];
+            } elsif ($key =~ s!\{\}$!!) {
+                $stash->{$key} = { map __get_value($_, $val, $uri), @nodes };
             } else {
                 $stash->{$key} = __get_value($nodes[0], $val, $uri);
             }

--- a/t/20-process_hashref.t
+++ b/t/20-process_hashref.t
@@ -1,0 +1,46 @@
+use strict;
+use Test::Base;
+
+use Data::Dumper;
+use Web::Scraper;
+plan tests => 1 * blocks;
+
+filters {
+    selector => 'chomp',
+    arg      => 'chomp',
+    callback => 'chomp',
+    expected => 'yaml',
+};
+
+run {
+    my $block = shift;
+    my $s = scraper {
+        process $block->selector, $block->arg, sub {
+            my $node = shift;
+            my %hash = eval $block->callback;
+            fail $@ if $@;
+            return %hash;
+        }
+    };
+    my $data = $s->scrape($block->html);
+    is_deeply $data, $block->expected, $block->name;
+};
+
+__DATA__
+
+===
+--- html
+<ul>
+<li><a href="foo.html">foo</a></li>
+<li><a href="bar.html">bar</a></li>
+</ul>
+--- selector
+ul>li>a
+--- arg
+sites{}
+--- callback
+($node->as_text, $node->attr('href'))
+--- expected
+sites:
+  foo : foo.html
+  bar : bar.html


### PR DESCRIPTION
In addition to a scalar and an array ref, I added a third type, a hashref.  It must be paired with a callback which returns a hash  (as Web::Scraper cannot guess how to key your hash.)    

Thank you for a useful module.  When I get a little time I will rework the documentation, as well.
