### PR TITLE
Track new URL of HTTP redirects to get correct relative links in HTML

### DIFF
--- a/lib/Web/Scraper.pm
+++ b/lib/Web/Scraper.pm
@@ -68,7 +68,7 @@ sub scrape {
         } else {
             croak "GET " . $stuff->request->uri . " failed: ", $stuff->status_line;
         }
-        $current ||= $stuff->request->uri;
+        $current = $stuff->request->uri;
     } elsif (blessed($stuff) && $stuff->isa('HTML::Element')) {
         $tree = $stuff->clone;
     } elsif (ref($stuff) && ref($stuff) eq 'SCALAR') {


### PR DESCRIPTION
This fixes a problem when scraping, say, this URL:

http://mysite/something/

which is actually a 301 redirect to:

http://mysite/something

Imagine the page contains a link like this:

<a href="another.html">...</a>

Before this change, the page is crawled fine, but all such page-relative
links on it were wrong because they were based on the originally
requested URL, not the one that was redirected to.

So that link would appear as:

http://mysite/something/another.html

which likely never existed, rather than the correct:

http://mysite/another.html

The solution is to always interrogate the response object to get its
URL, not trusting the URL we started with.